### PR TITLE
fix: Dockerfile missing assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY assets/ assets/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command


### PR DESCRIPTION
Assets were missing from Dockerfile and causing error:

```
$ docker build .
[...]
 => CACHED [builder 8/9] COPY controllers/ controllers/                                                                                                          0.0s
 => ERROR [builder 9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go                                                                 0.6s
------                                                                                                                                                                
 > [builder 9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go:                                                                            
0.553 controllers/game_controller_handlers.go:7:2: no required module provides package github.com/akyriako/kube-dosbox/assets; to add it:
0.553   go get github.com/akyriako/kube-dosbox/assets
------
Dockerfile:25
--------------------
  23 |     # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
  24 |     # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
  25 | >>> RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
  26 |     
  27 |     # Use distroless as minimal base image to package the manager binary
--------------------
ERROR: failed to solve: process "/bin/sh -c CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go" did not complete successfully: exit code: 1
```